### PR TITLE
Update for Laravel 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.0",
-        "illuminate/cache": "~5.0",
+        "illuminate/support": "~5.0|^6.0",
+        "illuminate/cache": "~5.0|^6.0",
         "guzzlehttp/guzzle":"~5.3|~6.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "~6.0",
+      "phpunit/phpunit": ">=6.0",
       "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/src/SlackApi.php
+++ b/src/SlackApi.php
@@ -3,8 +3,8 @@
 namespace Wgmv\SlackApi;
 
 use GuzzleHttp\Client;
-use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Wgmv\SlackApi\Contracts\SlackApi as Contract;
 
 class SlackApi implements Contract
@@ -26,13 +26,13 @@ class SlackApi implements Contract
     /**
      * Url to slack.com, by default will use https://slack.com/api.
      *
-     * @var String
+     * @var string
      */
     private $url = 'https://slack.com/api';
 
     /**
      * @param Client|null $client
-     * @param String|null $token
+     * @param string|null $token
      */
     public function __construct(Client $client = null, $token = null)
     {
@@ -169,7 +169,7 @@ class SlackApi implements Contract
     /**
      * Configures the Guzzle Client.
      *
-     * @param \GuzzleHttp\Client|Callback|null $client
+     * @param \GuzzleHttp\Client|callback|null $client
      */
     public function setClient($client = null)
     {
@@ -188,8 +188,9 @@ class SlackApi implements Contract
 
     /**
      * Performs an HTTP Request.
-     * @param string $verb HTTP Verb
-     * @param string $url Url to the request
+     *
+     * @param string $verb       HTTP Verb
+     * @param string $url        Url to the request
      * @param array  $parameters parameters to send
      *
      * @return array
@@ -207,7 +208,7 @@ class SlackApi implements Contract
             $response = $this->getHttpClient()->$verb($url, $parameters);
         }
 
-        /** @var  $contents */
+        /** @var $contents */
         $contents = $this->responseToJson($response);
 
         return $contents;
@@ -215,6 +216,7 @@ class SlackApi implements Contract
 
     /**
      * @param \GuzzleHttp\Psr7\Response|\GuzzleHttp\Message\Response $response
+     *
      * @return array
      */
     protected function responseToJson($response)
@@ -232,7 +234,7 @@ class SlackApi implements Contract
     protected function mergeParameters($parameters = [])
     {
         $options['query'] = [
-            't' => time(),
+            't'     => time(),
             'token' => $this->getToken(),
         ];
 

--- a/src/SlackApi.php
+++ b/src/SlackApi.php
@@ -4,6 +4,7 @@ namespace Wgmv\SlackApi;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Str;
 use Wgmv\SlackApi\Contracts\SlackApi as Contract;
 
 class SlackApi implements Contract
@@ -130,17 +131,17 @@ class SlackApi implements Contract
      */
     public function load($method)
     {
-        if (str_contains($method, '.')) {
+        if (Str::contains($method, '.')) {
             return app($method);
         }
 
-        $contract = __NAMESPACE__.'\\Contracts\\Slack'.studly_case($method);
+        $contract = __NAMESPACE__.'\\Contracts\\Slack'.Str::studly($method);
 
         if (class_exists($contract)) {
             return app($contract);
         }
 
-        return app('slack.'.snake_case($method));
+        return app('slack.'.Str::snake($method));
     }
 
     /**
@@ -263,7 +264,7 @@ class SlackApi implements Contract
      */
     protected function getUrl($method = null)
     {
-        return str_finish($this->url, '/').$method;
+        return Str::finish($this->url, '/').$method;
     }
 
     /**

--- a/src/SlackApiServiceProvider.php
+++ b/src/SlackApiServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Wgmv\SlackApi;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class SlackApiServiceProvider extends ServiceProvider
 {
@@ -16,6 +16,7 @@ class SlackApiServiceProvider extends ServiceProvider
 
     /**
      * Methods to register.
+     *
      * @var array
      */
     protected $methods = [
@@ -50,10 +51,9 @@ class SlackApiServiceProvider extends ServiceProvider
         $this->app->alias('Wgmv\SlackApi\Contracts\SlackApi', 'slack.api');
 
         foreach ($this->methods as $method) {
-
             $contract = "Wgmv\SlackApi\Contracts\Slack".$method;
             $class = "Wgmv\SlackApi\Methods\\".$method;
-            $shortcut = "slack.".Str::snake($method);
+            $shortcut = 'slack.'.Str::snake($method);
 
             $this->app->singleton($contract, function () use ($class) {
                 return new $class($this->app['slack.api']);
@@ -61,7 +61,6 @@ class SlackApiServiceProvider extends ServiceProvider
 
             $this->app->alias($contract, $shortcut);
         }
-
     }
 
     /**
@@ -74,9 +73,9 @@ class SlackApiServiceProvider extends ServiceProvider
         $shortcuts[] = 'slack.api';
 
         foreach ($this->methods as $method) {
-            $shortcuts[] = $shortcut = "slack.".Str::snake($method);
+            $shortcuts[] = $shortcut = 'slack.'.Str::snake($method);
         }
+
         return $shortcuts;
     }
-
 }

--- a/src/SlackApiServiceProvider.php
+++ b/src/SlackApiServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Wgmv\SlackApi;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class SlackApiServiceProvider extends ServiceProvider
@@ -38,7 +39,7 @@ class SlackApiServiceProvider extends ServiceProvider
     public function register()
     {
         /* Lumen autoload services configs */
-        if (str_contains($this->app->version(), 'Lumen')) {
+        if (Str::contains($this->app->version(), 'Lumen')) {
             $this->app->configure('services');
         }
 
@@ -52,7 +53,7 @@ class SlackApiServiceProvider extends ServiceProvider
 
             $contract = "Wgmv\SlackApi\Contracts\Slack".$method;
             $class = "Wgmv\SlackApi\Methods\\".$method;
-            $shortcut = "slack.".snake_case($method);
+            $shortcut = "slack.".Str::snake($method);
 
             $this->app->singleton($contract, function () use ($class) {
                 return new $class($this->app['slack.api']);
@@ -73,7 +74,7 @@ class SlackApiServiceProvider extends ServiceProvider
         $shortcuts[] = 'slack.api';
 
         foreach ($this->methods as $method) {
-            $shortcuts[] = $shortcut = "slack.".snake_case($method);
+            $shortcuts[] = $shortcut = "slack.".Str::snake($method);
         }
         return $shortcuts;
     }


### PR DESCRIPTION
This PR updates this package to allow for installs on a Laravel 6.x project. Merging this PR fixes #2. 

The following changes were made: 

- Add `illuminate` versions that support 6.x
- Change `phpunit` version constraint to support `>=6.0`
- Replace deprecated `Str` helper functions with their support class method implementations

Let me know if you have any questions. Thanks!